### PR TITLE
Append file extensions in xml2bom and stickerbom

### DIFF
--- a/scripts/stickerbom.py
+++ b/scripts/stickerbom.py
@@ -459,6 +459,8 @@ if __name__ == "__main__":
     if len(sys.argv) == 3:
         xmlpath = sys.argv[1]
         pdfpath = sys.argv[2]
+        if pdfpath[-4:].lower() != ".pdf":
+            pdfpath += ".pdf"
         main(xmlpath, pdfpath)
     else:
         print("Usage: {} <bompath.xml> <outpath.pdf>".format(sys.argv[0]))

--- a/scripts/xml2bom.py
+++ b/scripts/xml2bom.py
@@ -206,5 +206,8 @@ Assembly BOM
 
 print(report)
 if args.output:
-    with open(args.output, 'w') as f:
+    filename = args.output
+    if filename[-4:].lower() != ".bom":
+        filename += ".bom"
+    with open(filename, 'w') as f:
         f.write(report)


### PR DESCRIPTION
As it stands kicad defaults to calling BOM extensions with just the project name, with no extension.  This means stickerbom produces "teapot" rather than "teapot.pdf" and xml2bom produces "teapot" rather than "teapot.bom".  One can manually add the extensions to the kicad plugin command, but this is confusing.

The proposed changes make xml2bom append ".bom" if it is not already part of the output filename.  Stickerbom appends ".pdf" if it is not already part of the filename.