### PR TITLE
Reference standard kicad 3d models

### DIFF
--- a/agg.pretty/0201-L.kicad_mod
+++ b/agg.pretty/0201-L.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "0201-L" 
   (layer F.Cu) 
-  (tedit 56846B1E) 
+  (tedit 57654490) 
   (fp_text reference REF** 
     (at -1.4100 0 90) 
     (layer F.Fab) 
@@ -73,4 +73,11 @@
   (pad 2 smd rect 
     (at 0.2800 0) 
     (size 0.3600 0.3200) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0201.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/0201.kicad_mod
+++ b/agg.pretty/0201.kicad_mod
@@ -1,7 +1,7 @@
 
 (module 0201 
   (layer F.Cu) 
-  (tedit 56836635) 
+  (tedit 57654490) 
   (fp_text reference REF** 
     (at -1.5100 0 90) 
     (layer F.Fab) 
@@ -73,4 +73,11 @@
   (pad 2 smd rect 
     (at 0.3300 0) 
     (size 0.4600 0.4200) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0201.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/0402-L.kicad_mod
+++ b/agg.pretty/0402-L.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "0402-L" 
   (layer F.Cu) 
-  (tedit 568455D1) 
+  (tedit 57654490) 
   (fp_text reference REF** 
     (at -1.6100 0 90) 
     (layer F.Fab) 
@@ -73,4 +73,11 @@
   (pad 2 smd rect 
     (at 0.4000 0) 
     (size 0.5200 0.5200) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0402.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/0402.kicad_mod
+++ b/agg.pretty/0402.kicad_mod
@@ -1,7 +1,7 @@
 
 (module 0402 
   (layer F.Cu) 
-  (tedit 56836635) 
+  (tedit 57654490) 
   (fp_text reference REF** 
     (at -1.7100 0 90) 
     (layer F.Fab) 
@@ -73,4 +73,11 @@
   (pad 2 smd rect 
     (at 0.4500 0) 
     (size 0.6200 0.6200) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0402.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/0603-L.kicad_mod
+++ b/agg.pretty/0603-L.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "0603-L" 
   (layer F.Cu) 
-  (tedit 568455D1) 
+  (tedit 57654490) 
   (fp_text reference REF** 
     (at -2.0250 0 90) 
     (layer F.Fab) 
@@ -93,4 +93,11 @@
   (pad 2 smd rect 
     (at 0.7000 0) 
     (size 0.7500 0.9000) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0603.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/0603-LED.kicad_mod
+++ b/agg.pretty/0603-LED.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "0603-LED" 
   (layer F.Cu) 
-  (tedit 568457C2) 
+  (tedit 5765467B) 
   (fp_text reference REF** 
     (at -2.2250 0 90) 
     (layer F.Fab) 
@@ -93,4 +93,11 @@
   (pad 2 smd rect 
     (at 0.8000 0) 
     (size 0.9500 1.0000) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/LEDs.3dshapes/LED_0603.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 180))))

--- a/agg.pretty/0603.kicad_mod
+++ b/agg.pretty/0603.kicad_mod
@@ -1,7 +1,7 @@
 
 (module 0603 
   (layer F.Cu) 
-  (tedit 56836635) 
+  (tedit 57654490) 
   (fp_text reference REF** 
     (at -2.2250 0 90) 
     (layer F.Fab) 
@@ -93,4 +93,11 @@
   (pad 2 smd rect 
     (at 0.8000 0) 
     (size 0.9500 1.0000) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0603.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/0805-LED.kicad_mod
+++ b/agg.pretty/0805-LED.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "0805-LED" 
   (layer F.Cu) 
-  (tedit 568457C2) 
+  (tedit 5765467B) 
   (fp_text reference REF** 
     (at -2.4250 0 90) 
     (layer F.Fab) 
@@ -93,4 +93,11 @@
   (pad 2 smd rect 
     (at 0.9000 0) 
     (size 1.1500 1.4500) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/LEDs.3dshapes/LED_0805.wrl" 
+    (at 
+      (xyz -0.0060 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/0805.kicad_mod
+++ b/agg.pretty/0805.kicad_mod
@@ -1,7 +1,7 @@
 
 (module 0805 
   (layer F.Cu) 
-  (tedit 56836635) 
+  (tedit 57654490) 
   (fp_text reference REF** 
     (at -2.4250 0 90) 
     (layer F.Fab) 
@@ -93,4 +93,11 @@
   (pad 2 smd rect 
     (at 0.9000 0) 
     (size 1.1500 1.4500) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0805.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/1206.kicad_mod
+++ b/agg.pretty/1206.kicad_mod
@@ -1,7 +1,7 @@
 
 (module 1206 
   (layer F.Cu) 
-  (tedit 56836635) 
+  (tedit 57654490) 
   (fp_text reference REF** 
     (at -3.0250 0 90) 
     (layer F.Fab) 
@@ -93,4 +93,11 @@
   (pad 2 smd rect 
     (at 1.5000 0) 
     (size 1.1500 1.8000) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_1206.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/1210.kicad_mod
+++ b/agg.pretty/1210.kicad_mod
@@ -1,7 +1,7 @@
 
 (module 1210 
   (layer F.Cu) 
-  (tedit 56E0A4B3) 
+  (tedit 57654490) 
   (fp_text reference REF** 
     (at -3.0250 0 90) 
     (layer F.Fab) 
@@ -113,4 +113,11 @@
   (pad 2 smd rect 
     (at 1.5000 0) 
     (size 1.1500 2.7000) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_1210.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DFN-10-EP-LT.kicad_mod
+++ b/agg.pretty/DFN-10-EP-LT.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DFN-10-EP-LT" 
   (layer F.Cu) 
-  (tedit 5687759E) 
+  (tedit 5765711F) 
   (fp_text reference REF** 
     (at 0 -2.5000) 
     (layer F.Fab) 
@@ -281,4 +281,11 @@
     (at 0 0) 
     (size 1.6500 2.3800) 
     (layers F.Cu F.Mask) 
-    (solder_mask_margin 0.0010)))
+    (solder_mask_margin 0.0010)) 
+  (model "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/DFN-10-1EP_3x3mm_Pitch0.5mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DFN-12-EP-LT.kicad_mod
+++ b/agg.pretty/DFN-12-EP-LT.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DFN-12-EP-LT" 
   (layer F.Cu) 
-  (tedit 568F03CA) 
+  (tedit 5765711F) 
   (fp_text reference REF** 
     (at 0 -2.5000) 
     (layer F.Fab) 
@@ -319,4 +319,11 @@
     (at 0 0) 
     (size 1.6500 2.3800) 
     (layers F.Cu F.Mask) 
-    (solder_mask_margin 0.0010)))
+    (solder_mask_margin 0.0010)) 
+  (model "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/DFN-12-1EP_3x3mm_Pitch0.45mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DFN-16-EP-LTC-DE.kicad_mod
+++ b/agg.pretty/DFN-16-EP-LTC-DE.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DFN-16-EP-LTC-DE" 
   (layer F.Cu) 
-  (tedit 56C4C75B) 
+  (tedit 5765711F) 
   (fp_text reference REF** 
     (at 0 -3.0000) 
     (layer F.Fab) 
@@ -414,4 +414,11 @@
   (pad EP smd rect 
     (at 0 0) 
     (size 1.7000 3.3000) 
-    (layers F.Cu)))
+    (layers F.Cu)) 
+  (model "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/DFN-16-1EP_3x4mm_Pitch0.45mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DFN-6-EP-ONSEMI.kicad_mod
+++ b/agg.pretty/DFN-6-EP-ONSEMI.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DFN-6-EP-ONSEMI" 
   (layer F.Cu) 
-  (tedit 57602F7F) 
+  (tedit 5765711F) 
   (fp_text reference REF** 
     (at 0 -1.9500) 
     (layer F.Fab) 
@@ -205,4 +205,11 @@
     (at 0 0) 
     (size 0.9500 1.7000) 
     (layers F.Cu F.Mask) 
-    (solder_mask_margin 0.0010)))
+    (solder_mask_margin 0.0010)) 
+  (model "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/DFN-6-1EP_2x2mm_Pitch0.65mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DFN-8-EP-AD.kicad_mod
+++ b/agg.pretty/DFN-8-EP-AD.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DFN-8-EP-AD" 
   (layer F.Cu) 
-  (tedit 57268C9E) 
+  (tedit 5765711F) 
   (fp_text reference REF** 
     (at 0 -2.5000) 
     (layer F.Fab) 
@@ -272,4 +272,11 @@
   (pad EP smd rect 
     (at 0 0) 
     (size 1.8000 2.5000) 
-    (layers F.Cu)))
+    (layers F.Cu)) 
+  (model "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/DFN-8-1EP_3x3mm_Pitch0.5mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DFN-8-EP-MICROCHIP.kicad_mod
+++ b/agg.pretty/DFN-8-EP-MICROCHIP.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DFN-8-EP-MICROCHIP" 
   (layer F.Cu) 
-  (tedit 56B170E7) 
+  (tedit 5765711F) 
   (fp_text reference REF** 
     (at 0 -2.5000) 
     (layer F.Fab) 
@@ -252,4 +252,11 @@
   (pad EP smd rect 
     (at 0 0) 
     (size 1.5500 2.4000) 
-    (layers F.Cu)))
+    (layers F.Cu)) 
+  (model "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/DFN-8-1EP_3x3mm_Pitch0.65mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-02.kicad_mod
+++ b/agg.pretty/DIL-254P-02.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-02" 
   (layer F.Cu) 
-  (tedit 56C3F8AA) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -0.0000 1.2700) 
     (size 1.9000 1.9000) 
@@ -90,4 +90,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x01.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-04.kicad_mod
+++ b/agg.pretty/DIL-254P-04.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-04" 
   (layer F.Cu) 
-  (tedit 56C3F8AA) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -1.2700 1.2700) 
     (size 1.9000 1.9000) 
@@ -100,4 +100,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x02.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-06.kicad_mod
+++ b/agg.pretty/DIL-254P-06.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-06" 
   (layer F.Cu) 
-  (tedit 56C3F8AA) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -2.5400 1.2700) 
     (size 1.9000 1.9000) 
@@ -110,4 +110,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x03.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-08.kicad_mod
+++ b/agg.pretty/DIL-254P-08.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-08" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -3.8100 1.2700) 
     (size 1.9000 1.9000) 
@@ -120,4 +120,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x04.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-10.kicad_mod
+++ b/agg.pretty/DIL-254P-10.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-10" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -5.0800 1.2700) 
     (size 1.9000 1.9000) 
@@ -130,4 +130,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x05.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-12.kicad_mod
+++ b/agg.pretty/DIL-254P-12.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-12" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -6.3500 1.2700) 
     (size 1.9000 1.9000) 
@@ -140,4 +140,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x06.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-14.kicad_mod
+++ b/agg.pretty/DIL-254P-14.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-14" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -7.6200 1.2700) 
     (size 1.9000 1.9000) 
@@ -150,4 +150,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x07.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-16.kicad_mod
+++ b/agg.pretty/DIL-254P-16.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-16" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -8.8900 1.2700) 
     (size 1.9000 1.9000) 
@@ -160,4 +160,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x08.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-18.kicad_mod
+++ b/agg.pretty/DIL-254P-18.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-18" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -10.1600 1.2700) 
     (size 1.9000 1.9000) 
@@ -170,4 +170,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x09.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-20.kicad_mod
+++ b/agg.pretty/DIL-254P-20.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-20" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -11.4300 1.2700) 
     (size 1.9000 1.9000) 
@@ -180,4 +180,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x10.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-22.kicad_mod
+++ b/agg.pretty/DIL-254P-22.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-22" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -12.7000 1.2700) 
     (size 1.9000 1.9000) 
@@ -190,4 +190,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x11.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-24.kicad_mod
+++ b/agg.pretty/DIL-254P-24.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-24" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -13.9700 1.2700) 
     (size 1.9000 1.9000) 
@@ -200,4 +200,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x12.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-26.kicad_mod
+++ b/agg.pretty/DIL-254P-26.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-26" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -15.2400 1.2700) 
     (size 1.9000 1.9000) 
@@ -210,4 +210,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x13.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-28.kicad_mod
+++ b/agg.pretty/DIL-254P-28.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-28" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -16.5100 1.2700) 
     (size 1.9000 1.9000) 
@@ -220,4 +220,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x14.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-30.kicad_mod
+++ b/agg.pretty/DIL-254P-30.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-30" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -17.7800 1.2700) 
     (size 1.9000 1.9000) 
@@ -230,4 +230,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x15.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-32.kicad_mod
+++ b/agg.pretty/DIL-254P-32.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-32" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -19.0500 1.2700) 
     (size 1.9000 1.9000) 
@@ -240,4 +240,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x16.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-34.kicad_mod
+++ b/agg.pretty/DIL-254P-34.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-34" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -20.3200 1.2700) 
     (size 1.9000 1.9000) 
@@ -250,4 +250,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x17.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-36.kicad_mod
+++ b/agg.pretty/DIL-254P-36.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-36" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -21.5900 1.2700) 
     (size 1.9000 1.9000) 
@@ -260,4 +260,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x18.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-38.kicad_mod
+++ b/agg.pretty/DIL-254P-38.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-38" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -22.8600 1.2700) 
     (size 1.9000 1.9000) 
@@ -270,4 +270,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x19.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/DIL-254P-40.kicad_mod
+++ b/agg.pretty/DIL-254P-40.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DIL-254P-40" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -24.1300 1.2700) 
     (size 1.9000 1.9000) 
@@ -280,4 +280,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_2x20.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/HVQFN24-NXP.kicad_mod
+++ b/agg.pretty/HVQFN24-NXP.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "HVQFN24-NXP" 
   (layer F.Cu) 
-  (tedit 56E01099) 
+  (tedit 5765711F) 
   (fp_text reference REF** 
     (at 0 -3.4500) 
     (layer F.Fab) 
@@ -595,4 +595,11 @@
   (pad EP smd rect 
     (at 0 0) 
     (size 2.1000 2.1000) 
-    (layers F.Cu)))
+    (layers F.Cu)) 
+  (model "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-24-1EP_4x4mm_Pitch0.5mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/LQFP-100.kicad_mod
+++ b/agg.pretty/LQFP-100.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "LQFP-100" 
   (layer F.Cu) 
-  (tedit 5680BDC3) 
+  (tedit 5765711F) 
   (fp_text reference REF** 
     (at 0 -9.4000) 
     (layer F.Fab) 
@@ -1985,4 +1985,11 @@
   (pad 100 smd rect 
     (at -6.0000 -7.7000) 
     (size 0.3000 1.5000) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Housings_QFP.3dshapes/LQFP-100_14x14mm_Pitch0.5mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/LQFP-48.kicad_mod
+++ b/agg.pretty/LQFP-48.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "LQFP-48" 
   (layer F.Cu) 
-  (tedit 5680BCD7) 
+  (tedit 5765711F) 
   (fp_text reference REF** 
     (at 0 -5.9000) 
     (layer F.Fab) 
@@ -997,4 +997,11 @@
   (pad 48 smd rect 
     (at -2.7500 -4.2000) 
     (size 0.3000 1.5000) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Housings_QFP.3dshapes/LQFP-48_7x7mm_Pitch0.5mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/LQFP-64.kicad_mod
+++ b/agg.pretty/LQFP-64.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "LQFP-64" 
   (layer F.Cu) 
-  (tedit 5680BCD7) 
+  (tedit 5765711F) 
   (fp_text reference REF** 
     (at 0 -7.4000) 
     (layer F.Fab) 
@@ -1301,4 +1301,11 @@
   (pad 64 smd rect 
     (at -3.7500 -5.7000) 
     (size 0.3000 1.5000) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Housings_QFP.3dshapes/LQFP-64_10x10mm_Pitch0.5mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/MSOP-8.kicad_mod
+++ b/agg.pretty/MSOP-8.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "MSOP-8" 
   (layer F.Cu) 
-  (tedit 5680BCD7) 
+  (tedit 57656747) 
   (fp_text reference REF** 
     (at 0 -2.5000) 
     (layer F.Fab) 
@@ -237,4 +237,11 @@
   (pad 8 smd rect 
     (at 2.2000 -0.9750) 
     (size 1.4500 0.4500) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Housings_SSOP.3dshapes/MSOP-8_3x3mm_Pitch0.65mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/QFN-16-EP-NXP.kicad_mod
+++ b/agg.pretty/QFN-16-EP-NXP.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-16-EP-NXP" 
   (layer F.Cu) 
-  (tedit 56E08897) 
+  (tedit 5765711F) 
   (fp_text reference REF** 
     (at 0 -2.9500) 
     (layer F.Fab) 
@@ -424,4 +424,11 @@
     (at 0 0) 
     (size 1.5000 1.5000) 
     (layers F.Cu F.Mask) 
-    (solder_mask_margin 0.0010)))
+    (solder_mask_margin 0.0010)) 
+  (model "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-16-1EP_3x3mm_Pitch0.5mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/QFN-16-EP-SKYWORKS.kicad_mod
+++ b/agg.pretty/QFN-16-EP-SKYWORKS.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-16-EP-SKYWORKS" 
   (layer F.Cu) 
-  (tedit 56B2BF34) 
+  (tedit 5765711F) 
   (fp_text reference REF** 
     (at 0 -2.7700) 
     (layer F.Fab) 
@@ -478,4 +478,11 @@
     (at 0 0) 
     (size 1.7800 1.7800) 
     (layers F.Cu F.Mask) 
-    (solder_mask_margin 0.0010)))
+    (solder_mask_margin 0.0010)) 
+  (model "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-16-1EP_3x3mm_Pitch0.5mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/QFN-16-EP-TI.kicad_mod
+++ b/agg.pretty/QFN-16-EP-TI.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-16-EP-TI" 
   (layer F.Cu) 
-  (tedit 56E08A4D) 
+  (tedit 5765711F) 
   (fp_text reference REF** 
     (at 0 -2.6500) 
     (layer F.Fab) 
@@ -433,4 +433,11 @@
     (at 0 0) 
     (size 1.7000 1.7000) 
     (layers F.Cu F.Mask) 
-    (solder_mask_margin 0.0010)))
+    (solder_mask_margin 0.0010)) 
+  (model "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-16-1EP_3x3mm_Pitch0.5mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/QFN-20-EP-SI.kicad_mod
+++ b/agg.pretty/QFN-20-EP-SI.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-20-EP-SI" 
   (layer F.Cu) 
-  (tedit 5687759E) 
+  (tedit 57656747) 
   (fp_text reference REF** 
     (at 0 -3.3250) 
     (layer F.Fab) 
@@ -500,4 +500,11 @@
     (at 0 0) 
     (size 2.6000 2.6000) 
     (layers F.Cu F.Mask) 
-    (solder_mask_margin 0.0010)))
+    (solder_mask_margin 0.0010)) 
+  (model "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-20-1EP_4x4mm_Pitch0.5mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/QFN-24-EP-MAX.kicad_mod
+++ b/agg.pretty/QFN-24-EP-MAX.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-24-EP-MAX" 
   (layer F.Cu) 
-  (tedit 56B8D8F5) 
+  (tedit 5765711F) 
   (fp_text reference REF** 
     (at 0 -3.3050) 
     (layer F.Fab) 
@@ -595,4 +595,11 @@
   (pad EP smd rect 
     (at 0 0) 
     (size 2.6000 2.6000) 
-    (layers F.Cu)))
+    (layers F.Cu)) 
+  (model "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-24-1EP_4x4mm_Pitch0.5mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/QFN-32-EP-ST.kicad_mod
+++ b/agg.pretty/QFN-32-EP-ST.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-32-EP-ST" 
   (layer F.Cu) 
-  (tedit 56F82741) 
+  (tedit 57656747) 
   (fp_text reference REF** 
     (at 0 -3.6000) 
     (layer F.Fab) 
@@ -741,4 +741,11 @@
   (pad EP smd rect 
     (at 0 0) 
     (size 3.4500 3.4500) 
-    (layers F.Cu)))
+    (layers F.Cu)) 
+  (model "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-32-1EP_5x5mm_Pitch0.5mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/QFN-40-EP-LTC-UJ.kicad_mod
+++ b/agg.pretty/QFN-40-EP-LTC-UJ.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-40-EP-LTC-UJ" 
   (layer F.Cu) 
-  (tedit 56E1CFA1) 
+  (tedit 5765711F) 
   (fp_text reference REF** 
     (at 0 -4.2000) 
     (layer F.Fab) 
@@ -1073,4 +1073,11 @@
   (pad EP smd rect 
     (at 0 0) 
     (size 4.4200 4.4200) 
-    (layers F.Cu)))
+    (layers F.Cu)) 
+  (model "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-40-1EP_6x6mm_Pitch0.5mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/QFN-40-EP-UBLOX.kicad_mod
+++ b/agg.pretty/QFN-40-EP-UBLOX.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-40-EP-UBLOX" 
   (layer F.Cu) 
-  (tedit 569BC51E) 
+  (tedit 5765711F) 
   (fp_text reference REF** 
     (at 0 -3.6000) 
     (layer F.Fab) 
@@ -1073,4 +1073,11 @@
   (pad EP smd rect 
     (at 0 0) 
     (size 3.7000 3.7000) 
-    (layers F.Cu)))
+    (layers F.Cu)) 
+  (model "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-40-1EP_5x5mm_Pitch0.4mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/QFN-48-EP-ST.kicad_mod
+++ b/agg.pretty/QFN-48-EP-ST.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-48-EP-ST" 
   (layer F.Cu) 
-  (tedit 56AE9706) 
+  (tedit 57656747) 
   (fp_text reference REF** 
     (at 0 -4.6000) 
     (layer F.Fab) 
@@ -1105,4 +1105,11 @@
   (pad EP smd rect 
     (at 0 0) 
     (size 5.6000 5.6000) 
-    (layers F.Cu)))
+    (layers F.Cu)) 
+  (model "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-48-1EP_7x7mm_Pitch0.5mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SC-70-5.kicad_mod
+++ b/agg.pretty/SC-70-5.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SC-70-5" 
   (layer F.Cu) 
-  (tedit 56B01661) 
+  (tedit 5765688A) 
   (fp_text reference REF** 
     (at 0 -2.0250) 
     (layer F.Fab) 
@@ -180,4 +180,11 @@
   (pad 5 smd rect 
     (at 1.1000 -0.6500) 
     (size 0.9500 0.4000) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/TO_SOT_Packages_SMD.3dshapes/SC-70-5.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 90))))

--- a/agg.pretty/SIL-254P-01.kicad_mod
+++ b/agg.pretty/SIL-254P-01.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-01" 
   (layer F.Cu) 
-  (tedit 56C3F8AA) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -0.0000 0) 
     (size 1.9000 1.9000) 
@@ -80,4 +80,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x01.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-02.kicad_mod
+++ b/agg.pretty/SIL-254P-02.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-02" 
   (layer F.Cu) 
-  (tedit 56C3F8AA) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -1.2700 0) 
     (size 1.9000 1.9000) 
@@ -85,4 +85,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x02.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-03.kicad_mod
+++ b/agg.pretty/SIL-254P-03.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-03" 
   (layer F.Cu) 
-  (tedit 56C3F8AA) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -2.5400 0) 
     (size 1.9000 1.9000) 
@@ -90,4 +90,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x03.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-04.kicad_mod
+++ b/agg.pretty/SIL-254P-04.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-04" 
   (layer F.Cu) 
-  (tedit 56C3F8AA) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -3.8100 0) 
     (size 1.9000 1.9000) 
@@ -95,4 +95,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x04.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-05.kicad_mod
+++ b/agg.pretty/SIL-254P-05.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-05" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -5.0800 0) 
     (size 1.9000 1.9000) 
@@ -100,4 +100,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x05.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-06.kicad_mod
+++ b/agg.pretty/SIL-254P-06.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-06" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -6.3500 0) 
     (size 1.9000 1.9000) 
@@ -105,4 +105,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x06.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-07.kicad_mod
+++ b/agg.pretty/SIL-254P-07.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-07" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -7.6200 0) 
     (size 1.9000 1.9000) 
@@ -110,4 +110,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x07.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-08.kicad_mod
+++ b/agg.pretty/SIL-254P-08.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-08" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -8.8900 0) 
     (size 1.9000 1.9000) 
@@ -115,4 +115,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x08.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-09.kicad_mod
+++ b/agg.pretty/SIL-254P-09.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-09" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -10.1600 0) 
     (size 1.9000 1.9000) 
@@ -120,4 +120,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x09.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-10.kicad_mod
+++ b/agg.pretty/SIL-254P-10.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-10" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -11.4300 0) 
     (size 1.9000 1.9000) 
@@ -125,4 +125,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x10.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-11.kicad_mod
+++ b/agg.pretty/SIL-254P-11.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-11" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -12.7000 0) 
     (size 1.9000 1.9000) 
@@ -130,4 +130,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x11.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-12.kicad_mod
+++ b/agg.pretty/SIL-254P-12.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-12" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -13.9700 0) 
     (size 1.9000 1.9000) 
@@ -135,4 +135,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x12.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-13.kicad_mod
+++ b/agg.pretty/SIL-254P-13.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-13" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -15.2400 0) 
     (size 1.9000 1.9000) 
@@ -140,4 +140,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x13.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-14.kicad_mod
+++ b/agg.pretty/SIL-254P-14.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-14" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -16.5100 0) 
     (size 1.9000 1.9000) 
@@ -145,4 +145,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x14.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-15.kicad_mod
+++ b/agg.pretty/SIL-254P-15.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-15" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -17.7800 0) 
     (size 1.9000 1.9000) 
@@ -150,4 +150,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x15.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-16.kicad_mod
+++ b/agg.pretty/SIL-254P-16.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-16" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -19.0500 0) 
     (size 1.9000 1.9000) 
@@ -155,4 +155,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x16.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-17.kicad_mod
+++ b/agg.pretty/SIL-254P-17.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-17" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -20.3200 0) 
     (size 1.9000 1.9000) 
@@ -160,4 +160,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x17.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-18.kicad_mod
+++ b/agg.pretty/SIL-254P-18.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-18" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -21.5900 0) 
     (size 1.9000 1.9000) 
@@ -165,4 +165,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x18.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-19.kicad_mod
+++ b/agg.pretty/SIL-254P-19.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-19" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -22.8600 0) 
     (size 1.9000 1.9000) 
@@ -170,4 +170,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x19.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SIL-254P-20.kicad_mod
+++ b/agg.pretty/SIL-254P-20.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SIL-254P-20" 
   (layer F.Cu) 
-  (tedit 56C3F8AB) 
+  (tedit 57656D66) 
   (pad 1 thru_hole rect 
     (at -24.1300 0) 
     (size 1.9000 1.9000) 
@@ -175,4 +175,11 @@
     (effects 
       (font 
         (size 1.0000 1.0000) 
-        (thickness 0.1500)))))
+        (thickness 0.1500)))) 
+  (model "${KISYS3DMOD}/Pin_Headers.3dshapes/Pin_Header_Straight_1x20.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SOIC-16-W.kicad_mod
+++ b/agg.pretty/SOIC-16-W.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SOIC-16-W" 
   (layer F.Cu) 
-  (tedit 5680BCD7) 
+  (tedit 57656747) 
   (fp_text reference REF** 
     (at 0 -6.2000) 
     (layer F.Fab) 
@@ -389,4 +389,11 @@
   (pad 16 smd rect 
     (at 4.6500 -4.4450) 
     (size 2.0000 0.6000) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Housings_SOIC.3dshapes/SOIC-16_7.5x10.3mm_Pitch1.27mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SOIC-16.kicad_mod
+++ b/agg.pretty/SOIC-16.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SOIC-16" 
   (layer F.Cu) 
-  (tedit 5680BCD7) 
+  (tedit 57656747) 
   (fp_text reference REF** 
     (at 0 -5.9500) 
     (layer F.Fab) 
@@ -389,4 +389,11 @@
   (pad 16 smd rect 
     (at 2.7000 -4.4450) 
     (size 1.5500 0.6000) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Housings_SOIC.3dshapes/SOIC-16_3.9x9.9mm_Pitch1.27mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SOIC-8.kicad_mod
+++ b/agg.pretty/SOIC-8.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SOIC-8" 
   (layer F.Cu) 
-  (tedit 5680BCD7) 
+  (tedit 57656747) 
   (fp_text reference REF** 
     (at 0 -3.4500) 
     (layer F.Fab) 
@@ -237,4 +237,11 @@
   (pad 8 smd rect 
     (at 2.7000 -1.9050) 
     (size 1.5500 0.6000) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Housings_SOIC.3dshapes/SOIC-8_3.9x4.9mm_Pitch1.27mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SOT-23-5.kicad_mod
+++ b/agg.pretty/SOT-23-5.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SOT-23-5" 
   (layer F.Cu) 
-  (tedit 5686FE35) 
+  (tedit 57656747) 
   (fp_text reference REF** 
     (at 0 -2.4500) 
     (layer F.Fab) 
@@ -180,4 +180,11 @@
   (pad 5 smd rect 
     (at 1.3000 -0.9500) 
     (size 1.1000 0.6000) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/TO_SOT_Packages_SMD.3dshapes/SOT-23-5.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SOT-23-6.kicad_mod
+++ b/agg.pretty/SOT-23-6.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SOT-23-6" 
   (layer F.Cu) 
-  (tedit 56870086) 
+  (tedit 57656747) 
   (fp_text reference REF** 
     (at 0 -2.4750) 
     (layer F.Fab) 
@@ -199,4 +199,11 @@
   (pad 6 smd rect 
     (at 1.3000 -0.9500) 
     (size 1.1000 0.6000) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/TO_SOT_Packages_SMD.3dshapes/SOT-23-6.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/agg.pretty/SOT-23.kicad_mod
+++ b/agg.pretty/SOT-23.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SOT-23" 
   (layer F.Cu) 
-  (tedit 56870086) 
+  (tedit 5765688A) 
   (fp_text reference REF** 
     (at 0 -2.4500) 
     (layer F.Fab) 
@@ -142,4 +142,11 @@
   (pad 3 smd rect 
     (at 1.1500 0.0000) 
     (size 1.0000 0.6000) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/TO_SOT_Packages_SMD.3dshapes/SOT-23.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 90))))

--- a/agg.pretty/SOT-323.kicad_mod
+++ b/agg.pretty/SOT-323.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "SOT-323" 
   (layer F.Cu) 
-  (tedit 56F82741) 
+  (tedit 5765688A) 
   (fp_text reference REF** 
     (at 0 -2.0000) 
     (layer F.Fab) 
@@ -142,4 +142,11 @@
   (pad 3 smd rect 
     (at 1.0500 0.0000) 
     (size 0.8500 0.5500) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/TO_SOT_Packages_SMD.3dshapes/SOT-323.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 0.4000 0.4000 0.4000)) 
+    (rotate 
+      (xyz 0 0 -90))))

--- a/agg.pretty/TSSOP-20.kicad_mod
+++ b/agg.pretty/TSSOP-20.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "TSSOP-20" 
   (layer F.Cu) 
-  (tedit 57111950) 
+  (tedit 57656747) 
   (fp_text reference REF** 
     (at 0 -4.2500) 
     (layer F.Fab) 
@@ -465,4 +465,11 @@
   (pad 20 smd rect 
     (at 2.8750 -2.9250) 
     (size 1.3500 0.4500) 
-    (layers F.Cu F.Mask F.Paste)))
+    (layers F.Cu F.Mask F.Paste)) 
+  (model "${KISYS3DMOD}/Housings_SSOP.3dshapes/TSSOP-20_4.4x6.5mm_Pitch0.65mm.wrl" 
+    (at 
+      (xyz 0 0 0)) 
+    (scale 
+      (xyz 1 1 1)) 
+    (rotate 
+      (xyz 0 0 0))))

--- a/scripts/build_mod_chip.py
+++ b/scripts/build_mod_chip.py
@@ -34,6 +34,10 @@ config = {
         "chip_shape": (0.6, 0.3),
         "pin_shape": (-0.15, 0.3),
         "silk": None,
+        "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0201.wrl",
+                  "offset": (0,0,0),
+                  "scale": (1,1,1),
+                  "rotate": (0,0,0)},
     },
 
     # 0201-L from IPC-7351B: CAPC0603X33L
@@ -44,7 +48,11 @@ config = {
         "pin_shape": (-0.15, 0.3),
         "silk": None,
         "courtyard_gap": 0.10,
-    },
+        "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0201.wrl",
+                  "offset": (0,0,0),
+                  "scale": (1,1,1),
+                  "rotate": (0,0,0)},
+   },
 
     # 0402 from IPC-7351B: CAPC1005X55N
     "0402": {
@@ -53,7 +61,11 @@ config = {
         "chip_shape": (1.00, 0.50),
         "pin_shape": (-0.30, 0.50),
         "silk": None,
-    },
+        "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0402.wrl",
+                  "offset": (0,0,0),
+                  "scale": (1,1,1),
+                  "rotate": (0,0,0)},
+   },
 
     # 0402-L from IPC-7351B: CAPC1005X55L
     # This is a LEAST environment
@@ -64,7 +76,11 @@ config = {
         "pin_shape": (-0.30, 0.50),
         "silk": None,
         "courtyard_gap": 0.10,
-    },
+        "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0402.wrl",
+                  "offset": (0,0,0),
+                  "scale": (1,1,1),
+                  "rotate": (0,0,0)},
+   },
 
     # 0603 from IPC-7351B: CAPC1608X90N
     "0603": {
@@ -72,7 +88,11 @@ config = {
         "pitch": 1.60,
         "chip_shape": (1.60, 0.80),
         "pin_shape": (-0.35, 0.80),
-    },
+        "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0603.wrl",
+                  "offset": (0,0,0),
+                  "scale": (1,1,1),
+                  "rotate": (0,0,0)},
+   },
 
     # 0603-L from IPC-7351B: CAPC1608X90L
     # This is a LEAST environment
@@ -82,7 +102,11 @@ config = {
         "chip_shape": (1.60, 0.80),
         "pin_shape": (-0.35, 0.80),
         "courtyard_gap": 0.10,
-    },
+        "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0603.wrl",
+                  "offset": (0,0,0),
+                  "scale": (1,1,1),
+                  "rotate": (0,0,0)},
+   },
 
     # 0603-LED from IPC-7351B: CAPC1608X90N
     # Modified silkscreen to indicate LED polarity.
@@ -92,7 +116,11 @@ config = {
         "chip_shape": (1.60, 0.80),
         "pin_shape": (-0.25, 0.80),
         "silk": "triangle",
-    },
+        "model": {"path": "${KISYS3DMOD}/LEDs.3dshapes/LED_0603.wrl",
+                  "offset": (0,0,0),
+                  "scale": (1,1,1),
+                  "rotate": (0,0,180)},
+   },
 
     # 0805 from IPC-7351B: CAPC2013X100N
     "0805": {
@@ -100,7 +128,11 @@ config = {
         "pitch": 1.80,
         "chip_shape": (2.00, 1.25),
         "pin_shape": (-0.50, 1.25),
-    },
+        "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0805.wrl",
+                  "offset": (0,0,0),
+                  "scale": (1,1,1),
+                  "rotate": (0,0,0)},
+   },
 
     # 0805-LED from IPC-7351B: CAPC2013X100N
     # Modified silkscreen to indicate LED polarity.
@@ -110,7 +142,11 @@ config = {
         "chip_shape": (2.00, 1.25),
         "pin_shape": (-0.50, 1.25),
         "silk": "triangle",
-    },
+        "model": {"path": "${KISYS3DMOD}/LEDs.3dshapes/LED_0805.wrl",
+                  "offset": (-0.006,0,0),
+                  "scale": (1,1,1),
+                  "rotate": (0,0,0)},
+   },
 
     # 1206 from IPC-7351B: CAPC3216X130N
     "1206": {
@@ -118,7 +154,11 @@ config = {
         "pitch": 3.00,
         "chip_shape": (3.20, 1.60),
         "pin_shape": (-0.60, 1.60),
-    },
+        "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_1206.wrl",
+                  "offset": (0,0,0),
+                  "scale": (1,1,1),
+                  "rotate": (0,0,0)},
+   },
 
     # 1210 from IPC-7351B: CAPC3225X230N
     "1210": {
@@ -126,7 +166,11 @@ config = {
         "pitch": 3.0,
         "chip_shape": (3.20, 2.50),
         "pin_shape": (-0.60, 2.30),
-    },
+        "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_1210.wrl",
+                  "offset": (0,0,0),
+                  "scale": (1,1,1),
+                  "rotate": (0,0,0)},
+   },
 
     # SOD-323 from IPC-7351B: SOD2513X100L
     "SOD-323": {
@@ -219,7 +263,7 @@ import time
 import math
 
 from sexp import parse as sexp_parse, generate as sexp_generate
-from kicad_mod import fp_line, fp_text, pad, draw_square
+from kicad_mod import fp_line, fp_text, pad, draw_square, model
 
 
 def refs(conf):
@@ -344,6 +388,14 @@ def pads(conf):
     return out
 
 
+def _3d(conf):
+    """Add 3d model."""
+    if "model" in conf:
+        return [model(**conf['model'])]
+    else:
+        return []
+
+
 def footprint(conf):
     tedit = format(int(time.time()), 'X')
     sexp = ["module", conf['name'], ("layer", "F.Cu"), ("tedit", tedit)]
@@ -352,6 +404,7 @@ def footprint(conf):
     sexp += silk(conf)
     sexp += ctyd(conf)
     sexp += pads(conf)
+    sexp += _3d(conf)
     return sexp_generate(sexp)
 
 

--- a/scripts/build_mod_chip.py
+++ b/scripts/build_mod_chip.py
@@ -21,6 +21,11 @@ from __future__ import print_function, division
 #           What sort of silk to draw. Default is "internal".
 #   * courtyard_gap: minimum distance from footprint extreme to courtyard.
 #                    If not specified, the default ctyd_gap set below is used.
+#   * model: {"path": str,
+#             "offset": (x,y,z),
+#             "scale": (x,y,z),
+#             "rotate":(x,y,z)}
+#            Defines which 3D model to associate with the footprint.
 #
 # Except where otherwise noted, all packages are in IPC nominal environment.
 # Chip drawings are nominal sizes rather than maximum sizes.
@@ -35,9 +40,9 @@ config = {
         "pin_shape": (-0.15, 0.3),
         "silk": None,
         "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0201.wrl",
-                  "offset": (0,0,0),
-                  "scale": (1,1,1),
-                  "rotate": (0,0,0)},
+                  "offset": (0, 0, 0),
+                  "scale": (1, 1, 1),
+                  "rotate": (0, 0, 0)},
     },
 
     # 0201-L from IPC-7351B: CAPC0603X33L
@@ -49,10 +54,10 @@ config = {
         "silk": None,
         "courtyard_gap": 0.10,
         "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0201.wrl",
-                  "offset": (0,0,0),
-                  "scale": (1,1,1),
-                  "rotate": (0,0,0)},
-   },
+                  "offset": (0, 0, 0),
+                  "scale": (1, 1, 1),
+                  "rotate": (0, 0, 0)},
+    },
 
     # 0402 from IPC-7351B: CAPC1005X55N
     "0402": {
@@ -62,10 +67,10 @@ config = {
         "pin_shape": (-0.30, 0.50),
         "silk": None,
         "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0402.wrl",
-                  "offset": (0,0,0),
-                  "scale": (1,1,1),
-                  "rotate": (0,0,0)},
-   },
+                  "offset": (0, 0, 0),
+                  "scale": (1, 1, 1),
+                  "rotate": (0, 0, 0)},
+    },
 
     # 0402-L from IPC-7351B: CAPC1005X55L
     # This is a LEAST environment
@@ -77,10 +82,10 @@ config = {
         "silk": None,
         "courtyard_gap": 0.10,
         "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0402.wrl",
-                  "offset": (0,0,0),
-                  "scale": (1,1,1),
-                  "rotate": (0,0,0)},
-   },
+                  "offset": (0, 0, 0),
+                  "scale": (1, 1, 1),
+                  "rotate": (0, 0, 0)},
+    },
 
     # 0603 from IPC-7351B: CAPC1608X90N
     "0603": {
@@ -89,10 +94,10 @@ config = {
         "chip_shape": (1.60, 0.80),
         "pin_shape": (-0.35, 0.80),
         "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0603.wrl",
-                  "offset": (0,0,0),
-                  "scale": (1,1,1),
-                  "rotate": (0,0,0)},
-   },
+                  "offset": (0, 0, 0),
+                  "scale": (1, 1, 1),
+                  "rotate": (0, 0, 0)},
+    },
 
     # 0603-L from IPC-7351B: CAPC1608X90L
     # This is a LEAST environment
@@ -103,10 +108,10 @@ config = {
         "pin_shape": (-0.35, 0.80),
         "courtyard_gap": 0.10,
         "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0603.wrl",
-                  "offset": (0,0,0),
-                  "scale": (1,1,1),
-                  "rotate": (0,0,0)},
-   },
+                  "offset": (0, 0, 0),
+                  "scale": (1, 1, 1),
+                  "rotate": (0, 0, 0)},
+    },
 
     # 0603-LED from IPC-7351B: CAPC1608X90N
     # Modified silkscreen to indicate LED polarity.
@@ -117,10 +122,10 @@ config = {
         "pin_shape": (-0.25, 0.80),
         "silk": "triangle",
         "model": {"path": "${KISYS3DMOD}/LEDs.3dshapes/LED_0603.wrl",
-                  "offset": (0,0,0),
-                  "scale": (1,1,1),
-                  "rotate": (0,0,180)},
-   },
+                  "offset": (0, 0, 0),
+                  "scale": (1, 1, 1),
+                  "rotate": (0, 0, 180)},
+    },
 
     # 0805 from IPC-7351B: CAPC2013X100N
     "0805": {
@@ -129,10 +134,10 @@ config = {
         "chip_shape": (2.00, 1.25),
         "pin_shape": (-0.50, 1.25),
         "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_0805.wrl",
-                  "offset": (0,0,0),
-                  "scale": (1,1,1),
-                  "rotate": (0,0,0)},
-   },
+                  "offset": (0, 0, 0),
+                  "scale": (1, 1, 1),
+                  "rotate": (0, 0, 0)},
+    },
 
     # 0805-LED from IPC-7351B: CAPC2013X100N
     # Modified silkscreen to indicate LED polarity.
@@ -143,10 +148,10 @@ config = {
         "pin_shape": (-0.50, 1.25),
         "silk": "triangle",
         "model": {"path": "${KISYS3DMOD}/LEDs.3dshapes/LED_0805.wrl",
-                  "offset": (-0.006,0,0),
-                  "scale": (1,1,1),
-                  "rotate": (0,0,0)},
-   },
+                  "offset": (-0.006, 0, 0),
+                  "scale": (1, 1, 1),
+                  "rotate": (0, 0, 0)},
+    },
 
     # 1206 from IPC-7351B: CAPC3216X130N
     "1206": {
@@ -155,10 +160,10 @@ config = {
         "chip_shape": (3.20, 1.60),
         "pin_shape": (-0.60, 1.60),
         "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_1206.wrl",
-                  "offset": (0,0,0),
-                  "scale": (1,1,1),
-                  "rotate": (0,0,0)},
-   },
+                  "offset": (0, 0, 0),
+                  "scale": (1, 1, 1),
+                  "rotate": (0, 0, 0)},
+    },
 
     # 1210 from IPC-7351B: CAPC3225X230N
     "1210": {
@@ -167,10 +172,10 @@ config = {
         "chip_shape": (3.20, 2.50),
         "pin_shape": (-0.60, 2.30),
         "model": {"path": "${KISYS3DMOD}/Resistors_SMD.3dshapes/R_1210.wrl",
-                  "offset": (0,0,0),
-                  "scale": (1,1,1),
-                  "rotate": (0,0,0)},
-   },
+                  "offset": (0, 0, 0),
+                  "scale": (1, 1, 1),
+                  "rotate": (0, 0, 0)},
+    },
 
     # SOD-323 from IPC-7351B: SOD2513X100L
     "SOD-323": {

--- a/scripts/build_mod_ic.py
+++ b/scripts/build_mod_ic.py
@@ -47,6 +47,11 @@ from __future__ import print_function, division
 #   silk: "internal" or "external" or None.
 #          Default is "internal" unless ep_shape is given in which case
 #          default is "external".
+#   model: {"path": str,
+#           "offset": (x,y,z),
+#           "scale": (x,y,z),
+#           "rotate":(x,y,z)}
+#          Defines which 3D model to associate with the footprint.
 #
 # All lengths are in millimetres.
 
@@ -62,6 +67,12 @@ config = {
         "pad_shape": (1.55, 0.6),
         "chip_shape": (4.0, 5.0),
         "pin_shape": (1.1, 0.5),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_SOIC.3dshapes/SOIC-8_3.9x4.9mm_Pitch1.27mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # SOIC-16 from JEDEC MS-012AC
@@ -74,6 +85,12 @@ config = {
         "pad_shape": (1.55, 0.6),
         "chip_shape": (4.0, 10.0),
         "pin_shape": (1.1, 0.5),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_SOIC.3dshapes/SOIC-16_3.9x9.9mm_Pitch1.27mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # SOIC-16-W from JEDEC MS-013AA
@@ -86,6 +103,12 @@ config = {
         "pad_shape": (2.0, 0.6),
         "chip_shape": (7.6, 10.5),
         "pin_shape": (1.5, 0.5),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_SOIC.3dshapes/SOIC-16_7.5x10.3mm_Pitch1.27mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # MSOP-8 from JEDEC MO-187AA
@@ -98,6 +121,12 @@ config = {
         "pad_shape": (1.45, 0.45),
         "chip_shape": (3.1, 3.1),
         "pin_shape": (1.0, 0.38),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_SSOP.3dshapes/MSOP-8_3x3mm_Pitch0.65mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # TSSOP-20 from JEDEC MO-153AC
@@ -110,6 +139,12 @@ config = {
         "pad_shape": (1.35, 0.45),
         "chip_shape": (4.5, 6.6),
         "pin_shape": (0.95, .30),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_SSOP.3dshapes/TSSOP-20_4.4x6.5mm_Pitch0.65mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # LQFP-48 from JEDEC MS-026BBC
@@ -166,6 +201,12 @@ config = {
         "ep_vias": (0.4, 0.6, 1.9),
         "chip_shape": (7.1, 7.1),
         "pin_shape": (-0.5, 0.3),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-48-1EP_7x7mm_Pitch0.5mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # UFQFPN-32 from JEDEC MO-220
@@ -186,6 +227,12 @@ config = {
         "ep_vias": (0.4, 0.6, 1.9),
         "chip_shape": (5.1, 5.1),
         "pin_shape": (-0.5, 0.28),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-32-1EP_5x5mm_Pitch0.5mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # QFN-40 from JEDEC MO-220
@@ -222,6 +269,12 @@ config = {
         "ep_paste_shape": (1.1, 1.1, 0.2, 0.2),
         "chip_shape": (4.1, 4.1),
         "pin_shape": (-.50, 0.30),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-20-1EP_4x4mm_Pitch0.5mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # QFN-24 from MPU-9250 datasheet
@@ -390,6 +443,12 @@ config = {
         "pad_shape": (1.0, 0.6),
         "chip_shape": (1.4, 3.0),
         "pin_shape": (0.55, 0.48),
+        "model": {
+            "path": "${KISYS3DMOD}/TO_SOT_Packages_SMD.3dshapes/SOT-23.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 90),
+        },
     },
 
     # SOT-23-5
@@ -404,6 +463,12 @@ config = {
         "pad_shape": (1.10, 0.60),
         "chip_shape": (1.70, 3.00),
         "pin_shape": (0.75, 0.50),
+        "model": {
+            "path": "${KISYS3DMOD}/TO_SOT_Packages_SMD.3dshapes/SOT-23-5.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # SOT-23-6
@@ -417,6 +482,12 @@ config = {
         "pad_shape": (1.10, 0.60),
         "chip_shape": (1.75, 3.05),
         "pin_shape": (0.62, 0.50),
+        "model": {
+            "path": "${KISYS3DMOD}/TO_SOT_Packages_SMD.3dshapes/SOT-23-6.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # SC-70-5
@@ -431,6 +502,12 @@ config = {
         "pad_shape": (0.95, 0.40),
         "chip_shape": (1.4, 2.15),
         "pin_shape": (0.5, 0.3),
+        "model": {
+            "path": "${KISYS3DMOD}/TO_SOT_Packages_SMD.3dshapes/SC-70-5.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 90),
+        },
     },
 
     # SOT-323
@@ -444,6 +521,12 @@ config = {
         "pad_shape": (0.85, 0.55),
         "chip_shape": (1.35, 2.10),
         "pin_shape": (0.4, 0.3),
+        "model": {
+            "path": "${KISYS3DMOD}/TO_SOT_Packages_SMD.3dshapes/SOT-323.wrl",
+            "offset": (0, 0, 0),
+            "scale": (0.4, 0.4, 0.4),
+            "rotate": (0, 0, -90),
+        },
     },
 
     # SOT-666
@@ -629,7 +712,7 @@ import math
 import subprocess
 
 from sexp import parse as sexp_parse, generate as sexp_generate
-from kicad_mod import fp_line, fp_arc, fp_circle, fp_text, pad, draw_square
+from kicad_mod import fp_line, fp_arc, fp_circle, fp_text, pad, draw_square, model
 
 
 def pin_centres(conf):
@@ -975,6 +1058,13 @@ def pads(conf):
     return out
 
 
+def _3d(conf):
+    if "model" in conf:
+        return [model(**conf["model"])]
+    else:
+        return []
+
+
 def footprint(conf):
     tedit = format(int(time.time()), 'X')
     sexp = ["module", conf['name'], ("layer", "F.Cu"), ("tedit", tedit)]
@@ -983,6 +1073,7 @@ def footprint(conf):
     sexp += silk(conf)
     sexp += ctyd(conf)
     sexp += pads(conf)
+    sexp += _3d(conf)
     return sexp_generate(sexp)
 
 

--- a/scripts/build_mod_ic.py
+++ b/scripts/build_mod_ic.py
@@ -157,6 +157,12 @@ config = {
         "pad_shape": (1.5, 0.3),
         "chip_shape": (7.2, 7.2),
         "pin_shape": (1.0, 0.27),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_QFP.3dshapes/LQFP-48_7x7mm_Pitch0.5mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # LQFP-64 from JEDEC MS-026BCD
@@ -169,6 +175,12 @@ config = {
         "pad_shape": (1.5, 0.3),
         "chip_shape": (10.2, 10.2),
         "pin_shape": (1.0, 0.27),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_QFP.3dshapes/LQFP-64_10x10mm_Pitch0.5mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # LQFP-100 from JEDEC MS-026BED
@@ -181,6 +193,12 @@ config = {
         "pad_shape": (1.5, 0.3),
         "chip_shape": (14.2, 14.2),
         "pin_shape": (1.0, 0.27),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_QFP.3dshapes/LQFP-100_14x14mm_Pitch0.5mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # UFQFPN-48 from JEDEC MO-220
@@ -254,6 +272,12 @@ config = {
         "ep_vias": (0.4, 0.6, 0.45),
         "chip_shape": (5.1, 5.1),
         "pin_shape": (-0.35, 0.2),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-40-1EP_5x5mm_Pitch0.4mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # QFN-20 from JEDEC MO-220VGGD-8
@@ -303,6 +327,12 @@ config = {
         "ep_shape": (2.6, 2.6),
         "ep_mask_shape": (0.9, 0.9, 0.4, 0.4),
         "ep_paste_shape": (0.9, 0.9, 0.4, 0.4),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-24-1EP_4x4mm_Pitch0.5mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # QFN-16 from SKY65111-348LF datasheet
@@ -319,6 +349,12 @@ config = {
         "ep_shape": (1.78, 1.78),
         "ep_paste_shape": (0.7, 0.7, 0.3, 0.3),
         "ep_vias": (0.3, 0.4, 0.2),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-16-1EP_3x3mm_Pitch0.5mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # QFN-40 from LTC3887 datasheet
@@ -336,6 +372,12 @@ config = {
         "ep_vias": (0.4, 0.8, 0.43),
         "chip_shape": (6.0, 6.0),
         "pin_shape": (-0.4, 0.25),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-40-1EP_6x6mm_Pitch0.5mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # DFN-10 from JEDEC MO-229WEED-2
@@ -352,6 +394,12 @@ config = {
         "ep_paste_shape": (1.2, 0.8, 0, 0.4),
         "chip_shape": (3.1, 3.1),
         "pin_shape": (-0.40, 0.30),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/DFN-10-1EP_3x3mm_Pitch0.5mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # DFN-12
@@ -367,6 +415,12 @@ config = {
         "ep_paste_shape": (1.2, 0.8, 0, 0.4),
         "chip_shape": (3.1, 3.1),
         "pin_shape": (-0.40, 0.23),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/DFN-12-1EP_3x3mm_Pitch0.45mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # DFN-6-EP-BGM
@@ -395,6 +449,12 @@ config = {
         "ep_paste_shape": (.5, .5, .2, .2),
         "chip_shape": (2., 2.),
         "pin_shape": (-.35, .35),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/DFN-6-1EP_2x2mm_Pitch0.65mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # LPCC-16 for HMC5883L
@@ -556,7 +616,13 @@ config = {
         "ep_mask_shape": (0.8, 0.8, 0, 0.4),
         "ep_paste_shape": (0.8, 0.8, 0, 0.4),
         "chip_shape": (3.1, 3.1),
-        "pin_shape": (-0.3, 0.30)
+        "pin_shape": (-0.3, 0.30),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/DFN-8-1EP_3x3mm_Pitch0.65mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # DFN-8
@@ -571,7 +637,13 @@ config = {
         "ep_mask_shape": (0.8, 0.8, 0, 0.4),
         "ep_paste_shape": (0.8, 0.8, 0, 0.4),
         "chip_shape": (3.1, 3.1),
-        "pin_shape": (-0.5, 0.30)
+        "pin_shape": (-0.5, 0.30),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/DFN-8-1EP_3x3mm_Pitch0.5mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # DFN-16 from LTC4353
@@ -586,7 +658,13 @@ config = {
         "ep_mask_shape": (0.8, 0.8, 0.2, 0.4),
         "ep_paste_shape": (0.8, 0.8, 0.2, 0.4),
         "chip_shape": (3.1, 4.1),
-        "pin_shape": (-0.41, 0.28)
+        "pin_shape": (-0.41, 0.28),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/DFN-16-1EP_3x4mm_Pitch0.45mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # HVQFN24 from PCA9502
@@ -601,7 +679,13 @@ config = {
         "ep_mask_shape": (0.45, 0.45, 0.4, 0.4),
         "ep_paste_shape": (0.45, 0.45, 0.4, 0.4),
         "chip_shape": (4.3, 4.3),
-        "pin_shape": (-0.5, 0.3)
+        "pin_shape": (-0.5, 0.3),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-24-1EP_4x4mm_Pitch0.5mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # HVQFN-16 from PCAL9538A
@@ -615,7 +699,13 @@ config = {
         "ep_shape": (1.50, 1.50),
         "ep_paste_shape": (0.30, 0.30, 0.31, 0.31),
         "chip_shape": (3.0, 3.0),
-        "pin_shape": (-0.4, 0.24)
+        "pin_shape": (-0.4, 0.24),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-16-1EP_3x3mm_Pitch0.5mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # VQFN-16 from TPS6215
@@ -630,7 +720,13 @@ config = {
         "ep_paste_shape": (1.5, 1.5, 0.2, 0.2),
         "ep_vias": (0.2, 0.3, 0.9),
         "chip_shape": (3.0, 3.0),
-        "pin_shape": (-0.4, 0.25)
+        "pin_shape": (-0.4, 0.25),
+        "model": {
+            "path": "${KISYS3DMOD}/Housings_DFN_QFN.3dshapes/QFN-16-1EP_3x3mm_Pitch0.5mm.wrl",
+            "offset": (0, 0, 0),
+            "scale": (1, 1, 1),
+            "rotate": (0, 0, 0),
+        },
     },
 
     # XTAL 2.0x2.5mm

--- a/scripts/build_mod_sil_dil.py
+++ b/scripts/build_mod_sil_dil.py
@@ -45,7 +45,7 @@ import time
 import math
 
 from sexp import parse as sexp_parse, generate as sexp_generate
-from kicad_mod import fp_line, fp_text, pad, draw_square
+from kicad_mod import fp_line, fp_text, pad, draw_square, model
 
 
 def sil_pads(pins):
@@ -147,6 +147,28 @@ def dil_refs(name):
     return out
 
 
+def sil_model(pins):
+    if pins <= 20:
+        return [model("${KISYS3DMOD}/Pin_Headers.3dshapes/" +
+                      "Pin_Header_Straight_1x{:02d}.wrl".format(pins),
+                      (0, 0, 0),
+                      (1, 1, 1),
+                      (0, 0, 0))]
+    else:
+        return []
+
+
+def dil_model(pins):
+    if pins <= 40:
+        return [model("${KISYS3DMOD}/Pin_Headers.3dshapes/" +
+                      "Pin_Header_Straight_2x{:02d}.wrl".format(pins),
+                      (0, 0, 0),
+                      (1, 1, 1),
+                      (0, 0, 0))]
+    else:
+        return []
+
+
 def sil(pins):
     name = "SIL-254P-{:02d}".format(pins)
     tedit = format(int(time.time()), 'X')
@@ -156,6 +178,7 @@ def sil(pins):
     sexp += sil_silk(pins)
     sexp += sil_ctyd(pins)
     sexp += sil_refs(name)
+    sexp += sil_model(pins)
     return name, sexp_generate(sexp)
 
 
@@ -168,6 +191,7 @@ def dil(pins):
     sexp += dil_silk(pins)
     sexp += dil_ctyd(pins)
     sexp += dil_refs(name)
+    sexp += dil_model(pins)
     return name, sexp_generate(sexp)
 
 

--- a/scripts/kicad_mod.py
+++ b/scripts/kicad_mod.py
@@ -88,3 +88,10 @@ def draw_square(width, height, centre, layer, thickness):
     out.append(fp_line(se, sw, layer, thickness))
     out.append(fp_line(sw, nw, layer, thickness))
     return nw, ne, se, sw, out
+
+
+def model(path, offset, scale, rotate):
+    return ["model", path,
+            ["at", ["xyz", offset[0], offset[1], offset[2]]],
+            ["scale", ["xyz", scale[0], scale[1], scale[2]]],
+            ["rotate", ["xyz", rotate[0], rotate[1], rotate[2]]]]


### PR DESCRIPTION
Adds standard library kicad 3D models for mod_chip parts.
Partial solution to #58.