### PR TITLE
Tweak EP Paste Generation

### DIFF
--- a/agg.pretty/DFN-10-EP-LT.kicad_mod
+++ b/agg.pretty/DFN-10-EP-LT.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DFN-10-EP-LT" 
   (layer F.Cu) 
-  (tedit 5765711F) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -2.5000) 
     (layer F.Fab) 
@@ -267,15 +267,15 @@
     (at 1.4250 -1.0000) 
     (size 0.7000 0.2500) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 -0.6000) 
     (size 1.2000 0.8000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 0.6000) 
     (size 1.2000 0.8000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP smd rect 
     (at 0 0) 

--- a/agg.pretty/DFN-12-EP-LT.kicad_mod
+++ b/agg.pretty/DFN-12-EP-LT.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DFN-12-EP-LT" 
   (layer F.Cu) 
-  (tedit 5765711F) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -2.5000) 
     (layer F.Fab) 
@@ -305,15 +305,15 @@
     (at 1.4000 -1.1250) 
     (size 0.7000 0.2500) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 -0.6000) 
     (size 1.2000 0.8000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 0.6000) 
     (size 1.2000 0.8000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP smd rect 
     (at 0 0) 

--- a/agg.pretty/DFN-16-EP-LTC-DE.kicad_mod
+++ b/agg.pretty/DFN-16-EP-LTC-DE.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DFN-16-EP-LTC-DE" 
   (layer F.Cu) 
-  (tedit 5771B7BB) 
+  (tedit 577313DD) 
   (fp_text reference REF** 
     (at 0 -3.0000) 
     (layer F.Fab) 
@@ -381,20 +381,20 @@
     (at 1.4500 -1.5750) 
     (size 0.7000 0.2500) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 -1.2000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 0.0000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 1.2000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
   (pad "" smd rect 
     (at -0.0000 -1.2000) 

--- a/agg.pretty/DFN-16-EP-LTC-DE.kicad_mod
+++ b/agg.pretty/DFN-16-EP-LTC-DE.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DFN-16-EP-LTC-DE" 
   (layer F.Cu) 
-  (tedit 5765711F) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -3.0000) 
     (layer F.Fab) 
@@ -396,20 +396,20 @@
     (size 0.8000 0.8000) 
     (layers F.Cu F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 -1.2000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 0.0000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 1.2000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP smd rect 
     (at 0 0) 

--- a/agg.pretty/DFN-6-EP-BGM.kicad_mod
+++ b/agg.pretty/DFN-6-EP-BGM.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DFN-6-EP-BGM" 
   (layer F.Cu) 
-  (tedit 574B1A21) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -1.8000) 
     (layer F.Fab) 
@@ -191,25 +191,25 @@
     (at 1.0900 -0.5400) 
     (size 0.5000 0.2800) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.3500 -0.3500) 
     (size 0.5000 0.5000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.3500 0.3500) 
     (size 0.5000 0.5000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.3500 -0.3500) 
     (size 0.5000 0.5000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.3500 0.3500) 
     (size 0.5000 0.5000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP smd rect 
     (at 0 0) 

--- a/agg.pretty/DFN-6-EP-ONSEMI.kicad_mod
+++ b/agg.pretty/DFN-6-EP-ONSEMI.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DFN-6-EP-ONSEMI" 
   (layer F.Cu) 
-  (tedit 5765711F) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -1.9500) 
     (layer F.Fab) 
@@ -191,15 +191,15 @@
     (at 0.9150 -0.6500) 
     (size 0.4700 0.4000) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 -0.3500) 
     (size 0.5000 0.5000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 0.3500) 
     (size 0.5000 0.5000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP smd rect 
     (at 0 0) 

--- a/agg.pretty/DFN-8-EP-AD.kicad_mod
+++ b/agg.pretty/DFN-8-EP-AD.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DFN-8-EP-AD" 
   (layer F.Cu) 
-  (tedit 5771B7BB) 
+  (tedit 577313DD) 
   (fp_text reference REF** 
     (at 0 -2.5000) 
     (layer F.Fab) 
@@ -229,25 +229,25 @@
     (at 1.5500 -0.7500) 
     (size 0.6500 0.3500) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.4000 -0.6000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.4000 0.6000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.4000 -0.6000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.4000 0.6000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
   (pad "" smd rect 
     (at -0.4000 -0.6000) 

--- a/agg.pretty/DFN-8-EP-AD.kicad_mod
+++ b/agg.pretty/DFN-8-EP-AD.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DFN-8-EP-AD" 
   (layer F.Cu) 
-  (tedit 5765711F) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -2.5000) 
     (layer F.Fab) 
@@ -249,25 +249,25 @@
     (size 0.8000 0.8000) 
     (layers F.Cu F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.4000 -0.6000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.4000 0.6000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.4000 -0.6000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.4000 0.6000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP smd rect 
     (at 0 0) 

--- a/agg.pretty/DFN-8-EP-MICROCHIP.kicad_mod
+++ b/agg.pretty/DFN-8-EP-MICROCHIP.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DFN-8-EP-MICROCHIP" 
   (layer F.Cu) 
-  (tedit 5765711F) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -2.5000) 
     (layer F.Fab) 
@@ -239,15 +239,15 @@
     (size 0.8000 0.8000) 
     (layers F.Cu F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 -0.6000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 0.6000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP smd rect 
     (at 0 0) 

--- a/agg.pretty/DFN-8-EP-MICROCHIP.kicad_mod
+++ b/agg.pretty/DFN-8-EP-MICROCHIP.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "DFN-8-EP-MICROCHIP" 
   (layer F.Cu) 
-  (tedit 5771B7BB) 
+  (tedit 577313DD) 
   (fp_text reference REF** 
     (at 0 -2.5000) 
     (layer F.Fab) 
@@ -229,15 +229,15 @@
     (at 1.5500 -0.9750) 
     (size 0.6500 0.3500) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 -0.6000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 0.6000) 
     (size 0.8000 0.8000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
   (pad "" smd rect 
     (at -0.0000 -0.6000) 

--- a/agg.pretty/HVQFN24-NXP.kicad_mod
+++ b/agg.pretty/HVQFN24-NXP.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "HVQFN24-NXP" 
   (layer F.Cu) 
-  (tedit 5765711F) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -3.4500) 
     (layer F.Fab) 
@@ -572,25 +572,25 @@
     (size 0.4500 0.4500) 
     (layers F.Cu F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.4250 -0.4250) 
     (size 0.4500 0.4500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.4250 0.4250) 
     (size 0.4500 0.4500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.4250 -0.4250) 
     (size 0.4500 0.4500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.4250 0.4250) 
     (size 0.4500 0.4500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP smd rect 
     (at 0 0) 

--- a/agg.pretty/HVQFN24-NXP.kicad_mod
+++ b/agg.pretty/HVQFN24-NXP.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "HVQFN24-NXP" 
   (layer F.Cu) 
-  (tedit 5771B7BB) 
+  (tedit 577313DD) 
   (fp_text reference REF** 
     (at 0 -3.4500) 
     (layer F.Fab) 
@@ -552,25 +552,25 @@
     (at -1.2500 -2.0500) 
     (size 0.2400 0.9000) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.4250 -0.4250) 
     (size 0.4500 0.4500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.4250 0.4250) 
     (size 0.4500 0.4500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.4250 -0.4250) 
     (size 0.4500 0.4500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.4250 0.4250) 
     (size 0.4500 0.4500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
   (pad "" smd rect 
     (at -0.4250 -0.4250) 

--- a/agg.pretty/QFN-16-EP-NXP.kicad_mod
+++ b/agg.pretty/QFN-16-EP-NXP.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-16-EP-NXP" 
   (layer F.Cu) 
-  (tedit 5765711F) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -2.9500) 
     (layer F.Fab) 
@@ -400,25 +400,25 @@
     (at -0.7500 -1.5500) 
     (size 0.2400 0.9000) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.3050 -0.3050) 
     (size 0.3000 0.3000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.3050 0.3050) 
     (size 0.3000 0.3000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.3050 -0.3050) 
     (size 0.3000 0.3000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.3050 0.3050) 
     (size 0.3000 0.3000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP smd rect 
     (at 0 0) 

--- a/agg.pretty/QFN-16-EP-SKYWORKS.kicad_mod
+++ b/agg.pretty/QFN-16-EP-SKYWORKS.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-16-EP-SKYWORKS" 
   (layer F.Cu) 
-  (tedit 5765711F) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -2.7700) 
     (layer F.Fab) 
@@ -400,25 +400,25 @@
     (at -0.7500 -1.4300) 
     (size 0.2600 0.7800) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.5000 -0.5000) 
     (size 0.7000 0.7000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.5000 0.5000) 
     (size 0.7000 0.7000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.5000 -0.5000) 
     (size 0.7000 0.7000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.5000 0.5000) 
     (size 0.7000 0.7000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP thru_hole circle 
     (at -0.6000 -0.6000) 

--- a/agg.pretty/QFN-16-EP-TI.kicad_mod
+++ b/agg.pretty/QFN-16-EP-TI.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-16-EP-TI" 
   (layer F.Cu) 
-  (tedit 5765711F) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -2.6500) 
     (layer F.Fab) 
@@ -400,10 +400,10 @@
     (at -0.7500 -1.4000) 
     (size 0.2500 0.6000) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 -0.0000) 
     (size 1.5000 1.5000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP thru_hole circle 
     (at -0.6000 -0.6000) 

--- a/agg.pretty/QFN-20-EP-SI.kicad_mod
+++ b/agg.pretty/QFN-20-EP-SI.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-20-EP-SI" 
   (layer F.Cu) 
-  (tedit 57656747) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -3.3250) 
     (layer F.Fab) 
@@ -476,25 +476,25 @@
     (at -1.0000 -2.0000) 
     (size 0.3000 0.7500) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.6500 -0.6500) 
     (size 1.1000 1.1000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.6500 0.6500) 
     (size 1.1000 1.1000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.6500 -0.6500) 
     (size 1.1000 1.1000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.6500 0.6500) 
     (size 1.1000 1.1000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP smd rect 
     (at 0 0) 

--- a/agg.pretty/QFN-24-EP-MAX.kicad_mod
+++ b/agg.pretty/QFN-24-EP-MAX.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-24-EP-MAX" 
   (layer F.Cu) 
-  (tedit 5765711F) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -3.3050) 
     (layer F.Fab) 
@@ -572,25 +572,25 @@
     (size 0.9000 0.9000) 
     (layers F.Cu F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.6500 -0.6500) 
     (size 0.9000 0.9000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.6500 0.6500) 
     (size 0.9000 0.9000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.6500 -0.6500) 
     (size 0.9000 0.9000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.6500 0.6500) 
     (size 0.9000 0.9000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP smd rect 
     (at 0 0) 

--- a/agg.pretty/QFN-24-EP-MAX.kicad_mod
+++ b/agg.pretty/QFN-24-EP-MAX.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-24-EP-MAX" 
   (layer F.Cu) 
-  (tedit 5771B7BB) 
+  (tedit 577313DD) 
   (fp_text reference REF** 
     (at 0 -3.3050) 
     (layer F.Fab) 
@@ -552,25 +552,25 @@
     (at -1.2500 -1.9550) 
     (size 0.3000 0.8000) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.6500 -0.6500) 
     (size 0.9000 0.9000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.6500 0.6500) 
     (size 0.9000 0.9000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.6500 -0.6500) 
     (size 0.9000 0.9000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.6500 0.6500) 
     (size 0.9000 0.9000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
   (pad "" smd rect 
     (at -0.6500 -0.6500) 

--- a/agg.pretty/QFN-32-EP-ST.kicad_mod
+++ b/agg.pretty/QFN-32-EP-ST.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-32-EP-ST" 
   (layer F.Cu) 
-  (tedit 57656747) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -3.6000) 
     (layer F.Fab) 
@@ -709,10 +709,10 @@
     (size 2.0000 2.0000) 
     (layers F.Cu F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 -0.0000) 
     (size 1.0000 1.0000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP thru_hole circle 
     (at -1.2500 -1.2500) 

--- a/agg.pretty/QFN-32-EP-ST.kicad_mod
+++ b/agg.pretty/QFN-32-EP-ST.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-32-EP-ST" 
   (layer F.Cu) 
-  (tedit 5771B7BB) 
+  (tedit 577313DD) 
   (fp_text reference REF** 
     (at 0 -3.6000) 
     (layer F.Fab) 
@@ -704,10 +704,10 @@
     (at -1.7500 -2.3500) 
     (size 0.3000 0.6000) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 -0.0000) 
     (size 2.0000 2.0000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
   (pad "" smd rect 
     (at -0.0000 -0.0000) 

--- a/agg.pretty/QFN-40-EP-LTC-UJ.kicad_mod
+++ b/agg.pretty/QFN-40-EP-LTC-UJ.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-40-EP-LTC-UJ" 
   (layer F.Cu) 
-  (tedit 5771B7BB) 
+  (tedit 577313DD) 
   (fp_text reference REF** 
     (at 0 -4.2000) 
     (layer F.Fab) 
@@ -856,85 +856,85 @@
     (at -2.2500 -2.9000) 
     (size 0.2500 0.7000) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.8450 -1.8450) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.8450 -0.6150) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.8450 0.6150) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.8450 1.8450) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.6150 -1.8450) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.6150 -0.6150) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.6150 0.6150) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.6150 1.8450) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.6150 -1.8450) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.6150 -0.6150) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.6150 0.6150) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.6150 1.8450) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.8450 -1.8450) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.8450 -0.6150) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.8450 0.6150) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.8450 1.8450) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
   (pad "" smd rect 
     (at -1.8450 -1.8450) 

--- a/agg.pretty/QFN-40-EP-LTC-UJ.kicad_mod
+++ b/agg.pretty/QFN-40-EP-LTC-UJ.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-40-EP-LTC-UJ" 
   (layer F.Cu) 
-  (tedit 5765711F) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -4.2000) 
     (layer F.Fab) 
@@ -936,85 +936,85 @@
     (size 0.7300 0.7300) 
     (layers F.Cu F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.8450 -1.8450) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.8450 -0.6150) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.8450 0.6150) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.8450 1.8450) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.6150 -1.8450) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.6150 -0.6150) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.6150 0.6150) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.6150 1.8450) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.6150 -1.8450) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.6150 -0.6150) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.6150 0.6150) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.6150 1.8450) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.8450 -1.8450) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.8450 -0.6150) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.8450 0.6150) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.8450 1.8450) 
     (size 0.7300 0.7300) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP thru_hole circle 
     (at -1.2300 -1.2300) 

--- a/agg.pretty/QFN-40-EP-UBLOX.kicad_mod
+++ b/agg.pretty/QFN-40-EP-UBLOX.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-40-EP-UBLOX" 
   (layer F.Cu) 
-  (tedit 5771B7BB) 
+  (tedit 577313DD) 
   (fp_text reference REF** 
     (at 0 -3.6000) 
     (layer F.Fab) 
@@ -856,85 +856,85 @@
     (at -1.8000 -2.4000) 
     (size 0.2000 0.5000) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.5750 -1.5750) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.5750 -0.5250) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.5750 0.5250) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.5750 1.5750) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.5250 -1.5750) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.5250 -0.5250) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.5250 0.5250) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.5250 1.5750) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.5250 -1.5750) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.5250 -0.5250) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.5250 0.5250) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.5250 1.5750) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.5750 -1.5750) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.5750 -0.5250) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.5750 0.5250) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.5750 1.5750) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
   (pad "" smd rect 
     (at -1.5750 -1.5750) 

--- a/agg.pretty/QFN-40-EP-UBLOX.kicad_mod
+++ b/agg.pretty/QFN-40-EP-UBLOX.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-40-EP-UBLOX" 
   (layer F.Cu) 
-  (tedit 5765711F) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -3.6000) 
     (layer F.Fab) 
@@ -936,85 +936,85 @@
     (size 0.5500 0.5500) 
     (layers F.Cu F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.5750 -1.5750) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.5750 -0.5250) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.5750 0.5250) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.5750 1.5750) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.5250 -1.5750) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.5250 -0.5250) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.5250 0.5250) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.5250 1.5750) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.5250 -1.5750) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.5250 -0.5250) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.5250 0.5250) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 0.5250 1.5750) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.5750 -1.5750) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.5750 -0.5250) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.5750 0.5250) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.5750 1.5750) 
     (size 0.5500 0.5500) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP thru_hole circle 
     (at -1.0500 -1.0500) 

--- a/agg.pretty/QFN-48-EP-ST.kicad_mod
+++ b/agg.pretty/QFN-48-EP-ST.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-48-EP-ST" 
   (layer F.Cu) 
-  (tedit 5771B7BB) 
+  (tedit 577313DD) 
   (fp_text reference REF** 
     (at 0 -4.6000) 
     (layer F.Fab) 
@@ -1008,25 +1008,25 @@
     (at -2.7500 -3.3750) 
     (size 0.3000 0.5500) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.2500 -1.2500) 
     (size 2.0000 2.0000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.2500 1.2500) 
     (size 2.0000 2.0000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.2500 -1.2500) 
     (size 2.0000 2.0000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.2500 1.2500) 
     (size 2.0000 2.0000) 
-    (layers F.Cu F.Mask) 
+    (layers F.Mask) 
     (solder_mask_margin 0.0010)) 
   (pad "" smd rect 
     (at -1.2500 -1.2500) 

--- a/agg.pretty/QFN-48-EP-ST.kicad_mod
+++ b/agg.pretty/QFN-48-EP-ST.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "QFN-48-EP-ST" 
   (layer F.Cu) 
-  (tedit 57656747) 
+  (tedit 5771B7BB) 
   (fp_text reference REF** 
     (at 0 -4.6000) 
     (layer F.Fab) 
@@ -1028,25 +1028,25 @@
     (size 2.0000 2.0000) 
     (layers F.Cu F.Mask) 
     (solder_mask_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.2500 -1.2500) 
     (size 1.0000 1.0000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -1.2500 1.2500) 
     (size 1.0000 1.0000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.2500 -1.2500) 
     (size 1.0000 1.0000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at 1.2500 1.2500) 
     (size 1.0000 1.0000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP thru_hole circle 
     (at -2.5000 -2.5000) 

--- a/agg.pretty/WSON-10-EP-TI-2x3.kicad_mod
+++ b/agg.pretty/WSON-10-EP-TI-2x3.kicad_mod
@@ -1,7 +1,7 @@
 
 (module "WSON-10-EP-TI-2x3" 
   (layer F.Cu) 
-  (tedit 5771C5C9) 
+  (tedit 57731974) 
   (fp_text reference REF** 
     (at 0 -2.4500) 
     (layer F.Fab) 
@@ -267,15 +267,15 @@
     (at 0.9500 -1.0000) 
     (size 0.5000 0.2500) 
     (layers F.Cu F.Mask F.Paste)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 -0.6000) 
     (size 0.8400 1.0000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
-  (pad EP smd rect 
+  (pad "" smd rect 
     (at -0.0000 0.6000) 
     (size 0.8400 1.0000) 
-    (layers F.Cu F.Paste) 
+    (layers F.Paste) 
     (solder_paste_margin 0.0010)) 
   (pad EP thru_hole circle 
     (at -0.0000 -0.9500) 

--- a/scripts/build_mod_ic.py
+++ b/scripts/build_mod_ic.py
@@ -923,10 +923,10 @@ def exposed_pad(conf):
     else:
         paste_shape = conf['ep_paste_shape']
         apertures = inner_apertures(ep_shape, paste_shape)
-        layers = ["F.Cu", "F.Paste"]
+        layers = ["F.Paste"]
         for ap in apertures:
             out.append(
-                pad("EP", "smd", "rect", ap, paste_shape[:2], layers,
+                pad("", "smd", "rect", ap, paste_shape[:2], layers,
                     m_paste=.001))
 
     # Vias

--- a/scripts/build_mod_ic.py
+++ b/scripts/build_mod_ic.py
@@ -911,9 +911,9 @@ def exposed_pad(conf):
     else:
         mask_shape = conf['ep_mask_shape']
         apertures = inner_apertures(ep_shape, mask_shape)
-        layers = ["F.Cu", "F.Mask"]
+        layers = ["F.Mask"]
         for ap in apertures:
-            out.append(pad("EP", "smd", "rect", ap, mask_shape[:2], layers,
+            out.append(pad("", "smd", "rect", ap, mask_shape[:2], layers,
                            m_mask=.001))
 
     # Paste apertures


### PR DESCRIPTION
Tweak EP layer paste generation. EP paste pads are now no longer on any
copper layers, they are also no longer named "EP" to prevent DRC failures.