### PR TITLE
Avoid confusing error with pins on only one side

### DIFF
--- a/scripts/build_lib_ic.py
+++ b/scripts/build_lib_ic.py
@@ -59,6 +59,10 @@ def geometry(conf):
     width += width % 200
 
     # height is the maximum required on either side
+    if len(conf['pins']) != 2:
+        raise RuntimeError("IC schematic symbols must have at least one pin "
+                           "on the left and right sides and may only have two"
+                           "sides.")
     left_pins = sum(len(x) for x in conf['pins'][0])
     right_pins = sum(len(x) for x in conf['pins'][1])
     left_groups = len(conf['pins'][0])

--- a/scripts/build_lib_ic.py
+++ b/scripts/build_lib_ic.py
@@ -60,9 +60,8 @@ def geometry(conf):
 
     # height is the maximum required on either side
     if len(conf['pins']) != 2:
-        raise RuntimeError("IC schematic symbols must have at least one pin "
-                           "on the left and right sides and may only have two"
-                           "sides.")
+        raise RuntimeError("IC schematic symbols must list pins on exactly "
+                           "two sides.")
     left_pins = sum(len(x) for x in conf['pins'][0])
     right_pins = sum(len(x) for x in conf['pins'][1])
     left_groups = len(conf['pins'][0])


### PR DESCRIPTION
Previously if an IC schematic symbol only had pins on one side,
build_lib_ic.py would fail to index producing a confusing error.  This
change intercepts this problem and produces a more helpful error.