### PR TITLE
Python failover

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,18 @@ else
 	verboseflag =
 endif
 
-all: build compile check verify
+all: build compile check verify python
+
+python:
+ifeq (, $(shell which python3))
+ifeq (, $(shell which python))
+$(error "No python found -- install python2 or python3?")
+else
+PYTHON=python
+endif
+else
+PYTHON=python3
+endif
 
 build: build-libs build-mods
 
@@ -27,67 +38,67 @@ check: check-lib check-mod
 verify: build-verify compile-verify
 
 build-lib-connector:
-	python scripts/build_lib_connector.py lib/connector/conn.lib
+	${PYTHON} scripts/build_lib_connector.py lib/connector/conn.lib
 
 verify-lib-connector:
-	python scripts/build_lib_connector.py lib/connector/conn.lib --verify
+	${PYTHON} scripts/build_lib_connector.py lib/connector/conn.lib --verify
 
 build-lib-switch:
-	python scripts/build_lib_switch.py lib/ui/switch.lib
+	${PYTHON} scripts/build_lib_switch.py lib/ui/switch.lib
 
 verify-lib-switch:
-	python scripts/build_lib_switch.py lib/ui/switch.lib --verify $(verboseflag)
+	${PYTHON} scripts/build_lib_switch.py lib/ui/switch.lib --verify $(verboseflag)
 
 build-lib-ic:
-	python scripts/build_lib_ic.py lib/
+	${PYTHON} scripts/build_lib_ic.py lib/
 
 verify-lib-ic:
-	python scripts/build_lib_ic.py lib/ --verify $(verboseflag)
+	${PYTHON} scripts/build_lib_ic.py lib/ --verify $(verboseflag)
 
 build-lib-power:
-	python scripts/build_lib_power.py lib/power/power.lib
+	${PYTHON} scripts/build_lib_power.py lib/power/power.lib
 
 verify-lib-power:
-	python scripts/build_lib_power.py lib/power/power.lib --verify
+	${PYTHON} scripts/build_lib_power.py lib/power/power.lib --verify
 
 build-mod-chip:
-	python scripts/build_mod_chip.py agg.pretty/
+	${PYTHON} scripts/build_mod_chip.py agg.pretty/
 
 verify-mod-chip:
-	python scripts/build_mod_chip.py agg.pretty/ --verify $(verboseflag)
+	${PYTHON} scripts/build_mod_chip.py agg.pretty/ --verify $(verboseflag)
 
 build-mod-ic:
-	python scripts/build_mod_ic.py agg.pretty/
+	${PYTHON} scripts/build_mod_ic.py agg.pretty/
 
 verify-mod-ic:
-	python scripts/build_mod_ic.py agg.pretty/ --verify $(verboseflag)
+	${PYTHON} scripts/build_mod_ic.py agg.pretty/ --verify $(verboseflag)
 
 build-mod-jstpa:
-	python scripts/build_mod_jstpa.py agg.pretty/
+	${PYTHON} scripts/build_mod_jstpa.py agg.pretty/
 
 verify-mod-jstpa:
-	python scripts/build_mod_jstpa.py agg.pretty/ --verify $(verboseflag)
+	${PYTHON} scripts/build_mod_jstpa.py agg.pretty/ --verify $(verboseflag)
 
 build-mod-sil-dil:
-	python scripts/build_mod_sil_dil.py agg.pretty/
+	${PYTHON} scripts/build_mod_sil_dil.py agg.pretty/
 
 verify-mod-sil-dil:
-	python scripts/build_mod_sil_dil.py agg.pretty/ --verify $(verboseflag)
+	${PYTHON} scripts/build_mod_sil_dil.py agg.pretty/ --verify $(verboseflag)
 
 compile-lib:
-	python scripts/compile_lib.py lib/ agg-kicad.lib
+	${PYTHON} scripts/compile_lib.py lib/ agg-kicad.lib
 
 verify-lib:
-	python scripts/compile_lib.py lib/ agg-kicad.lib --verify
+	${PYTHON} scripts/compile_lib.py lib/ agg-kicad.lib --verify
 
 compile-pro:
-	python scripts/compile_pro.py lib/ agg-kicad.pro
+	${PYTHON} scripts/compile_pro.py lib/ agg-kicad.pro
 
 verify-pro:
-	python scripts/compile_pro.py lib/ agg-kicad.pro --verify
+	${PYTHON} scripts/compile_pro.py lib/ agg-kicad.pro --verify
 
 check-lib:
-	python scripts/check_lib.py lib/ agg.pretty/ $(verboseflag)
+	${PYTHON} scripts/check_lib.py lib/ agg.pretty/ $(verboseflag)
 
 check-mod:
-	python scripts/check_mod.py agg.pretty/ $(verboseflag)
+	${PYTHON} scripts/check_mod.py agg.pretty/ $(verboseflag)


### PR DESCRIPTION
Ideally use `python3` if present.  If it isn't, use `python2`.  If neither are present, print an error explaining the situation.

It is an improbable, but permissible, situation for a system to have `python3` but not `python2`.  The `python` alias is currently defined to point to `python2` by PEP 394.

Downside to this is it gets confusing with virtualenvs.  If you run `make` inside a python2 virtualenv, it will attempt to use `python3` from outside the virtualenv in preference to running the venv's `python2`/`python`