### PR TITLE
Add ibis2yaml script

### DIFF
--- a/scripts/ibis2yaml.py
+++ b/scripts/ibis2yaml.py
@@ -1,0 +1,48 @@
+"""
+    ibis2yaml.py
+    Copyright 2017 Russ Garrett
+    Licensed under the MIT licence, see LICENSE file for details.
+
+    Convert the pin names from an IBIS file (such as provided by
+    ST for the STM32 chips) into YAML suitable for putting into
+    a symbol definition file.
+"""
+import sys
+import re
+import yaml
+
+
+def parse(f):
+    results = []
+    for line in f:
+        if line[0] == '|':
+            continue
+        key = line.split(' ', 1)[0]
+        if key == '[Pin]':
+            # We're only interested in the [Pin] section here
+            for line in f:
+                if line[0] == '[':
+                    break
+                # Some lines are commented out with a | but still have useful info.
+                line = line.strip().lstrip('|').split()
+                if len(line) < 2:
+                    continue
+
+                if re.match(r'^[0-9]+$', line[0]):
+                    pin = int(line[0])
+                else:
+                    pin = str(line[0])
+
+                # Guess pin types for common labels
+                if re.match(r'^(VCC|VDD|VSS|VBAT)', line[1]):
+                    pin_type = 'pwrin'
+                elif re.match(r'^(NRST|BOOT0|VREF)', line[1]):
+                    pin_type = 'in'
+                else:
+                    pin_type = 'bidi'
+                results.append([line[1], pin, pin_type])
+    return results
+
+
+with open(sys.argv[1], 'r') as f:
+    print(yaml.dump([[parse(f)]]))


### PR DESCRIPTION
This adds a script which takes an IBIS (.ibs) file as provided by ST and
spits out YAML in the right format to put into a symbol def file.

Example:

```
$ python3 ./ibis2yaml.py ~/Downloads/en.stm32ibis/f103vbt.ibs 
- - - [PE2, 1, bidi]
    - [PE3, 2, bidi]
    - [PE4, 3, bidi]
    - [PE5, 4, bidi]
    - [PE6, 5, bidi]
    - [VBAT, 6, pwrin]
    - [PC13-ANTI_TAMP, 7, bidi]
    - [PC14-OSC32_IN, 8, bidi]
    - [PC15-OSC32_OUT, 9, bidi]
    - [VSS_5, 10, pwrin]
    - [VDD_5, 11, pwrin]
    - [OSC_IN, 12, bidi]
    - [OSC_OUT, 13, bidi]
    - [NRST, 14, in]
    - [PC0, 15, bidi]
    - [PC1, 16, bidi]
    - [PC2, 17, bidi]
    - [PC3, 18, bidi]
    - [VSSA, 19, pwrin]
    - [VREF-, 20, in]
    - [VREF+, 21, in]
    - [VDDA, 22, pwrin]
    - [PA0-WKUP, 23, bidi]
    - [PA1, 24, bidi]
    - [PA2, 25, bidi]
    - [PA3, 26, bidi]
    - [VSS_4, 27, pwrin]
    - [VDD_4, 28, pwrin]
    - [PA4, 29, bidi]
    - [PA5, 30, bidi]
    - [PA6, 31, bidi]
    - [PA7, 32, bidi]
    - [PC4, 33, bidi]
    - [PC5, 34, bidi]
    - [PB0, 35, bidi]
    - [PB1, 36, bidi]
    - [PB2, 37, bidi]
    - [PE7, 38, bidi]
    - [PE8, 39, bidi]
    - [PE9, 40, bidi]
    - [PE10, 41, bidi]
    - [PE11, 42, bidi]
    - [PE12, 43, bidi]
    - [PE13, 44, bidi]
    - [PE14, 45, bidi]
    - [PE15, 46, bidi]
    - [PB10, 47, bidi]
    - [PB11, 48, bidi]
    - [VSS_1, 49, pwrin]
    - [VDD_1, 50, pwrin]
    - [PB12, 51, bidi]
    - [PB13, 52, bidi]
    - [PB14, 53, bidi]
    - [PB15, 54, bidi]
    - [PD8, 55, bidi]
    - [PD9, 56, bidi]
    - [PD10, 57, bidi]
    - [PD11, 58, bidi]
    - [PD12, 59, bidi]
    - [PD13, 60, bidi]
    - [PD14, 61, bidi]
    - [PD15, 62, bidi]
    - [PC6, 63, bidi]
    - [PC7, 64, bidi]
    - [PC8, 65, bidi]
    - [PC9, 66, bidi]
    - [PA8, 67, bidi]
    - [PA9, 68, bidi]
    - [PA10, 69, bidi]
    - [PA11, 70, bidi]
    - [PA12, 71, bidi]
    - [PA13, 72, bidi]
    - [NC, 73, bidi]
    - [VSS_2, 74, pwrin]
    - [VDD_2, 75, pwrin]
    - [PA14, 76, bidi]
    - [PA15, 77, bidi]
    - [PC10, 78, bidi]
    - [PC11, 79, bidi]
    - [PC12, 80, bidi]
    - [PD0, 81, bidi]
    - [PD1, 82, bidi]
    - [PD2, 83, bidi]
    - [PD3, 84, bidi]
    - [PD4, 85, bidi]
    - [PD5, 86, bidi]
    - [PD6, 87, bidi]
    - [PD7, 88, bidi]
    - [PB3, 89, bidi]
    - [PB4, 90, bidi]
    - [PB5, 91, bidi]
    - [PB6, 92, bidi]
    - [PB7, 93, bidi]
    - [BOOT0, 94, in]
    - [PB8, 95, bidi]
    - [PB9, 96, bidi]
    - [PE0, 97, bidi]
    - [PE1, 98, bidi]
    - [VSS_3, 99, pwrin]
    - [VDD_3, 100, pwrin]
```